### PR TITLE
Fix arm cross-compilation

### DIFF
--- a/relm-gen-widget/src/gen.rs
+++ b/relm-gen-widget/src/gen.rs
@@ -377,7 +377,7 @@ fn gen_construct_widget(widget: &Widget) -> Tokens {
                 use gtk::StaticType;
                 use relm::{Downcast, FromGlibPtrNone, ToGlib};
                 ::gtk::Widget::from_glib_none(::relm::g_object_new(#struct_name::static_type().to_glib(),
-                #(#params,)* ::std::ptr::null() as *const i8) as *mut _)
+                #(#params,)* ::std::ptr::null() as *const _) as *mut _)
                 .downcast_unchecked()
             }
         }


### PR DESCRIPTION
Hello,

I try to cross-compile my application for a raspberry pi:

```
PKG_CONFIG_ALLOW_CROSS=1 cargo build --target arm-unknown-linux-gnueabihf --release
```

But I get many errors like:

```
error[E0308]: mismatched types
  --> src/widget/precise.rs:21:1
   |
21 | #[widget]
   | ^^^^^^^^^ expected u8, found i8
   |
   = note: expected type `*const u8`
              found type `*const i8`
   = help: here are some functions which might fulfill your needs:
           - .offset(...)
           - .wrapping_offset(...)
```