### PR TITLE
Allow relm_widget! to work in modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ macro_rules! relm_widget {
 #[macro_export]
 macro_rules! use_impl_self_type {
     (impl Widget for $self_type:ident { $($tts:tt)* }) => {
-        pub use __relm_gen_private::$self_type;
+        pub use self::__relm_gen_private::$self_type;
     };
 }
 


### PR DESCRIPTION
Basically this fixes a problem where if all the GUI code is isolated into a file (called `gui.rs`, for instance) `relm_widget!` breaks.