### PR TITLE
Update gtk version in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ First, add this to you `Cargo.toml`:
 
 [source,bash]
 ----
-gtk = "^0.1.2"
+gtk = "^0.2.0"
 relm = "^0.10.0"
 relm-derive = "^0.10.0"
 ----


### PR DESCRIPTION
cargo warns that two versions of glib is linked: 0.3.4 and 0.4.0

relm depends on gtk version "=0.2.0", so it would be sane to also suggest the user to use the same version.