### PR TITLE
Readme updates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,13 +34,7 @@ Next, add this to your crate:
 
 [source,rust]
 ----
-extern crate gtk;
-#[macro_use]
-extern crate relm;
-#[macro_use]
-extern crate relm_derive;
-
-use relm::{Relm, Widget};
+include::examples/readme.rs[lines=1..7]
 ----
 
 Then, create your model:

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,15 @@ Next, add this to your crate:
 
 [source,rust]
 ----
-include::examples/readme.rs[lines=1..7]
+extern crate gtk;
+#[macro_use]
+extern crate relm;
+#[macro_use]
+extern crate relm_derive;
+
+use relm::{Relm, Update, Widget};
+use gtk::prelude::*;
+use gtk::{Window, Inhibit, WindowType};
 ----
 
 Then, create your model:
@@ -92,24 +100,11 @@ impl Update for Win {
 
     // The model may be updated when a message is received.
     // Widgets may also be updated in this function.
-    // Futures and streams can be connected to send a message when a value is ready.
     fn update(&mut self, event: Msg) {
         match event {
-            Msg::SomeEvent => {
-                let future = create_future();
-                relm.connect_exec_ignore_err(future, SomeEvent);
-            },
             Msg::Quit => gtk::main_quit(),
         }
     }
-
-    // The next method is optional.
-    // Futures and streams can be connected when the `Widget` is created in the
-    // `subscriptions()` method.
-    // fn subscriptions(&mut self, relm: &Relm<Self>) {
-    //     let stream = Interval::new(Duration::from_secs(1));
-    //     relm.connect_exec_ignore_err(stream, Tick);
-    // }
 }
 
 impl Widget for Win {
@@ -182,6 +177,17 @@ Here is an example using this attribute:
 
 [source,rust]
 ----
+#[derive(Msg)]
+pub enum Msg {
+    Decrement,
+    Increment,
+    Quit,
+}
+
+pub struct Model {
+    counter: u32,
+}
+
 #[widget]
 impl Widget for Win {
     fn model() -> Model {
@@ -206,7 +212,7 @@ impl Widget for Win {
                 orientation: Vertical,
                 gtk::Button {
                     // By default, an event with one paramater is assumed.
-                    clicked => Increment,
+                    clicked => Msg::Increment,
                     // Hence, the previous line is equivalent to:
                     // clicked(_) => Increment,
                     label: "+",
@@ -219,13 +225,13 @@ impl Widget for Win {
                     text: &self.model.counter.to_string(),
                 },
                 gtk::Button {
-                    clicked => Decrement,
+                    clicked => Msg::Decrement,
                     label: "-",
                 },
             },
             // Use a tuple when you want to both send a message and return a value to
             // the GTK+ callback.
-            delete_event(_, _) => (Quit, Inhibit(false)),
+            delete_event(_, _) => (Msg::Quit, Inhibit(false)),
         }
     }
 }

--- a/examples/readme-attributes.rs
+++ b/examples/readme-attributes.rs
@@ -1,0 +1,75 @@
+extern crate gtk;
+#[macro_use]
+extern crate relm;
+#[macro_use]
+extern crate relm_derive;
+extern crate relm_attributes;
+
+use relm_attributes::widget;
+use relm::Widget;
+use gtk::prelude::*;
+use gtk::Inhibit;
+use gtk::Orientation::Vertical; 
+
+#[derive(Msg)]
+pub enum Msg {
+    Decrement,
+    Increment,
+    Quit,
+}
+
+pub struct Model {
+    counter: u32,
+}
+
+#[widget]
+impl Widget for Win {
+    fn model() -> Model {
+        Model {
+            counter: 0,
+        }
+    }
+
+    fn update(&mut self, event: Msg) {
+        match event {
+            // A call to self.label1.set_text() is automatically inserted by the
+            // attribute every time the model.counter attribute is updated.
+            Msg::Decrement => self.model.counter -= 1,
+            Msg::Increment => self.model.counter += 1,
+            Msg::Quit => gtk::main_quit(),
+        }
+    }
+
+    view! {
+        gtk::Window {
+            gtk::Box {
+                orientation: Vertical,
+                gtk::Button {
+                    // By default, an event with one paramater is assumed.
+                    clicked => Msg::Increment,
+                    // Hence, the previous line is equivalent to:
+                    // clicked(_) => Increment,
+                    label: "+",
+                },
+                gtk::Label {
+                    // Bind the text property of this Label to the counter attribute
+                    // of the model.
+                    // Every time the counter attribute is updated, the text property
+                    // will be updated too.
+                    text: &self.model.counter.to_string(),
+                },
+                gtk::Button {
+                    clicked => Msg::Decrement,
+                    label: "-",
+                },
+            },
+            // Use a tuple when you want to both send a message and return a value to
+            // the GTK+ callback.
+            delete_event(_, _) => (Msg::Quit, Inhibit(false)),
+        }
+    }
+}
+
+fn main() {
+    Win::run(()).unwrap();
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -4,4 +4,77 @@ extern crate relm;
 #[macro_use]
 extern crate relm_derive;
 
-use relm::{Relm, Widget};
+use relm::{Relm, Update, Widget};
+use gtk::prelude::*;
+use gtk::{Window, Inhibit, WindowType};
+
+#[derive(Msg)]
+enum Msg {
+    // …
+    Quit,
+}
+
+struct Model {
+    // …
+}
+
+struct Win {
+    // …
+    model: Model,
+    window: Window,
+}
+
+impl Update for Win {
+    // Specify the model used for this widget.
+    type Model = Model;
+    // Specify the model parameter used to init the model.
+    type ModelParam = ();
+    // Specify the type of the messages sent to the update function.
+    type Msg = Msg;
+
+    // Return the initial model.
+    fn model(_: &Relm<Self>, _: ()) -> Model {
+        Model {
+        }
+    }
+
+    // The model may be updated when a message is received.
+    // Widgets may also be updated in this function.
+    fn update(&mut self, event: Msg) {
+        match event {
+            Msg::Quit => gtk::main_quit(),
+        }
+    }
+}
+
+impl Widget for Win {
+    // Specify the type of the root widget.
+    type Root = Window;
+
+    // Return the root widget.
+    fn root(&self) -> Self::Root {
+        self.window.clone()
+    }
+
+    // Create the widgets.
+    fn view(relm: &Relm<Self>, model: Self::Model) -> Self {
+        // GTK+ widgets are used normally within a `Widget`.
+        let window = Window::new(WindowType::Toplevel);
+
+        // Connect the signal `delete_event` to send the `Quit` message.
+        connect!(relm, window, connect_delete_event(_, _), return (Some(Msg::Quit), Inhibit(false)));
+        // There is also a `connect!()` macro for GTK+ events that do not need a
+        // value to be returned in the callback.
+
+        window.show_all();
+
+        Win {
+            model,
+            window: window,
+        }
+    }
+}
+
+fn main() {
+    Win::run(()).unwrap();
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,0 +1,7 @@
+extern crate gtk;
+#[macro_use]
+extern crate relm;
+#[macro_use]
+extern crate relm_derive;
+
+use relm::{Relm, Widget};


### PR DESCRIPTION
fixes for https://github.com/antoyo/relm/issues/81

Removed references to using futures, since that has been removed. Added readme examples to the examples directory, once https://github.com/github/markup/issues/1095 is fixed by github you can include them directly.