### PR TITLE
Update `simplelog` to fix an error in it

### DIFF
--- a/examples/http/Cargo.toml
+++ b/examples/http/Cargo.toml
@@ -11,7 +11,7 @@ glib = "^0.6.0"
 glib-sys = "^0.7.0"
 gtk = "^0.5.0"
 json = "^0.11.5"
-simplelog = "^0.4.2"
+simplelog = "^0.5.3"
 uhttp_uri = "^0.5.1"
 
 [dependencies.relm]

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -70,7 +70,7 @@ use relm::{
 };
 use relm_attributes::widget;
 use simplelog::{Config, TermLogger};
-use simplelog::LogLevelFilter::Warn;
+use simplelog::LevelFilter::Warn;
 use uhttp_uri::HttpUri;
 
 use self::Msg::*;


### PR DESCRIPTION
This fixes this simplelog error

```
thread 'main' panicked at 'TermLogger::init failed: Term',
src/libcore/result.rs:1009:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```