### PR TITLE
Remove g_object_new_with_properties

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ repository = "antoyo/relm"
 [dependencies]
 cairo-rs = "^0.5.0"
 glib = "^0.6.0"
-glib-sys = "^0.7.0"
 gobject-sys = "^0.7.0"
 gtk = "^0.5.0"
-libc = "^0.2.22"
 
 [dependencies.relm-core]
 path = "relm-core"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,8 @@
 
 extern crate cairo;
 extern crate glib;
-extern crate glib_sys;
 extern crate gobject_sys;
 extern crate gtk;
-extern crate libc;
 extern crate relm_core;
 extern crate relm_state;
 
@@ -122,12 +120,9 @@ pub use glib::Cast;
 pub use glib::object::Downcast;
 #[doc(hidden)]
 pub use glib::translate::{FromGlibPtrNone, ToGlib, ToGlibPtr};
-use glib_sys::GType;
 #[doc(hidden)]
 pub use gobject_sys::{GParameter, g_object_newv};
-use gobject_sys::{GObject, GValue};
 use gtk::Continue;
-use libc::{c_char, c_uint};
 #[doc(hidden)]
 pub use relm_core::{Channel, EventStream, Sender};
 pub use relm_state::{
@@ -145,11 +140,6 @@ pub use component::Component;
 pub use container::{Container, ContainerComponent, ContainerWidget};
 pub use drawing::DrawHandler;
 pub use widget::{Widget, WidgetTest};
-
-extern "C" {
-    pub fn g_object_new_with_properties(object_type: GType, n_properties: c_uint, names: *mut *const c_char,
-                                        values: *mut *const GValue) -> *mut GObject;
-}
 
 /// Dummy macro to be used with `#[derive(Widget)]`.
 #[macro_export]


### PR DESCRIPTION
It's not used anywhere, and `glib::object::Object::new` now has the same capabilities.