### PR TITLE
Reexport `relm_core` types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub use glib::translate::{FromGlibPtrNone, ToGlib, ToGlibPtr};
 #[doc(hidden)]
 pub use gobject_sys::{GParameter, g_object_newv};
 use gtk::Continue;
-#[doc(hidden)]
+
 pub use relm_core::{Channel, EventStream, Sender};
 pub use relm_state::{
     DisplayVariant,


### PR DESCRIPTION
Not being able to name the types makes them rather useless. Even the relm examples rely on them, so just make them "official".