### PR TITLE
Fix view! widget with parentheses and braces

### DIFF
--- a/relm-gen-widget/src/parser.rs
+++ b/relm-gen-widget/src/parser.rs
@@ -545,6 +545,7 @@ impl RelmWidgetParser {
             else {
                 None
             };
+        let lookahead = input.lookahead1();
         let relm_widget =
             if lookahead.peek(token::Brace) {
                 let content;

--- a/tests/model-param-attribute.rs
+++ b/tests/model-param-attribute.rs
@@ -101,7 +101,8 @@ impl Widget for Win {
             gtk::Box {
                 // Set the orientation property of the Box.
                 orientation: Vertical,
-                Button(self.model.initial_text),
+                Button(self.model.initial_text){
+                },
                 #[name="label"]
                 gtk::Label {
                     // Bind the text property of the label to the counter attribute of the model.


### PR DESCRIPTION
* Recreate lookahead instance in RelmWidgetParser to account for the potentially consumed tokenstream between parentheses.
* Adjust tests/model-param-attribute to account for the change.

This should fix issue #162 