### PR TITLE
fix example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,7 +125,7 @@ impl Widget for Win {
 
         Win {
             model,
-            window: window,
+            window,
         }
     }
 }


### PR DESCRIPTION
the `window` field of `Win` has the same name as the variable used in the initialization, therefore it doesn't need to specify the field explicitly. Just like the `model` field on the line above