### PR TITLE
Fix tree-view example on Windows

### DIFF
--- a/relm-examples/examples/tree-view.rs
+++ b/relm-examples/examples/tree-view.rs
@@ -21,7 +21,7 @@
 
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{MAIN_SEPARATOR, PathBuf};
 
 use glib::StaticType;
 use gtk::{
@@ -177,7 +177,7 @@ fn create_and_fill_model(dir_str: &PathBuf) -> io::Result<gtk::ListStore> {
 
             if let Ok(file_name) = entry.file_name().into_string() {
                 let (final_name, is_dir) = if metadata.is_dir() {
-                    (format!("{}/", file_name), true)
+                    (format!("{}{}", file_name, MAIN_SEPARATOR), true)
                 } else {
                     (file_name, false)
                 };


### PR DESCRIPTION
Was trying out some of the examples and found that the `tree-view` example always crashed because of UNC paths (e.g. `\\\\?\\C:\\projects\\3rdparty`). I've used the `dunce` crate to handle removal of the `\\\\?\\` prefix on Windows, without changing functionality for non-Windows platforms.

Strangely enough, before this change, it works when loading the application (as I can see all the files), but then crashes once trying to move to another directory.