### PR TITLE
Adds type hinting in connect! macro

### DIFF
--- a/relm-examples/examples/menu.rs
+++ b/relm-examples/examples/menu.rs
@@ -52,7 +52,7 @@ impl Widget for Win {
         file_menu.append(&quit_item);
         self.menubar.show_all();
 
-        connect!(quit_item, connect_activate(_), self.model.relm, Quit);
+        connect!(self.model.relm, quit_item, connect_activate(_), Quit);
     }
 
     fn model(relm: &Relm<Self>, _: ()) -> Model {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,7 +37,8 @@
 macro_rules! connect {
     // Connect to a GTK+ widget event, sending a message to another widget.
     ($widget:expr, $event:ident($($args:pat),*), $other_component:expr, $msg:expr) => {
-        $crate::connect_stream!($widget, $event($($args),*), $other_component.stream(), $msg);
+        #[inline(always)] fn stream<WIDGET: relm::Widget>(c: &relm::Component<WIDGET>) -> &relm::EventStream<WIDGET::Msg> {c.stream()}
+        $crate::connect_stream!($widget, $event($($args),*), stream(&$other_component), $msg);
     };
 
     // Connect to a GTK+ widget event.


### PR DESCRIPTION
Fixes #194

This is a side-effect because the first form of the `connect` macro also works with `Relm` as 3rd argument.

I added a type hinting, I hope the error message is clear:
```
error[E0308]: mismatched types
  --> examples/menu.rs:55:9
   |
55 |         connect!(quit_item, connect_activate(_), self.model.relm, Quit);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `relm::component::Component`, found struct `relm::state::Relm`
   |
   = note: expected reference `&relm::component::Component<_>`
              found reference `&relm::state::Relm<Win>`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```