### PR TITLE
Crossbeam channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ gtk = "^0.8.0"
 libc = "^0.2.54"
 log = "^0.4.6"
 quote = "0.6"
+crossbeam-channel = "0.4.2"
 
 [dependencies.syn]
 features = ["full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ gobject-sys = "^0.9.0"
 gtk = "^0.8.0"
 libc = "^0.2.54"
 log = "^0.4.6"
-quote = "0.6"
 crossbeam-channel = "0.4.2"
 
 [dependencies.syn]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -34,11 +34,11 @@
 
 mod source;
 
+use crossbeam_channel::{Receiver, SendError};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::rc::Rc;
-use std::sync::mpsc::{self, Receiver, SendError};
 
 use self::source::{SourceFuncs, new_source, source_get};
 
@@ -62,10 +62,10 @@ struct ChannelData<MSG> {
     receiver: Receiver<MSG>,
 }
 
-/// A wrapper over a `std::sync::mpsc::Sender` to wakeup the glib event loop when sending a
+/// A wrapper over a `crossbeam_channel::Sender` to wakeup the glib event loop when sending a
 /// message.
 pub struct Sender<MSG> {
-    sender: mpsc::Sender<MSG>,
+    sender: crossbeam_channel::Sender<MSG>,
 }
 
 impl<MSG> Clone for Sender<MSG> {
@@ -95,7 +95,7 @@ pub struct Channel<MSG> {
 impl<MSG> Channel<MSG> {
     /// Create a new channel with a callback that will be called when a message is received.
     pub fn new<CALLBACK: FnMut(MSG) + 'static>(callback: CALLBACK) -> (Self, Sender<MSG>) {
-        let (sender, receiver) = mpsc::channel();
+        let (sender, receiver) = crossbeam_channel::unbounded();
         let source = new_source(RefCell::new(ChannelData {
             callback: Box::new(callback),
             peeked_value: None,


### PR DESCRIPTION
Hi, I needed to make this change for the way that I'm communicating with a Relm app from other parts of the code, specifically I need the `relm::Sender` to be `Send` which apparently the `std::mpsc::Sender` is not.  Crossbeam channels also have better performance, so it seems like a win to me.

I also noticed that Relm itself does not depend on quote so I removed it.