### PR TITLE
[Derive] Disable clippy for view()

### DIFF
--- a/relm-derive/src/gen/mod.rs
+++ b/relm-derive/src/gen/mod.rs
@@ -424,7 +424,7 @@ impl Driver {
         let (view, relm_widgets, container_impl) = gen::gen(name, &widget, self);
         let model_ident = Ident::new(MODEL_IDENT, Span::call_site()); // TODO: maybe need to set Span here.
         let code = quote_spanned! { name.span() =>
-            #[allow(unused_variables)] // Necessary to avoid warnings in case the parameters are unused.
+            #[allow(unused_variables,clippy::all)] // Necessary to avoid warnings in case the parameters are unused.
             fn view(relm: &::relm::Relm<Self>, #model_ident: Self::Model) -> Self {
                 #view
             }


### PR DESCRIPTION
Clippy produces hundreds of warnings related to the style of `view()`.

It quickly floods CI with useless lints, so finding actual ones becomes impossible
