### PR TITLE
use glib::timeout_add_local instead of deprecaed gtk::timout_add

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ pub fn run<WIDGET>(model_param: WIDGET::ModelParam) -> Result<(), ()>
 /// Emit the `msg` every `duration` ms.
 pub fn interval<F: Fn() -> MSG + 'static, MSG: 'static>(stream: &StreamHandle<MSG>, duration: u32, constructor: F) {
     let stream = stream.clone();
-    gtk::timeout_add(duration, move || {
+    glib::timeout_add_local(duration, move || {
         let msg = constructor();
         stream.emit(msg);
         Continue(true)
@@ -353,7 +353,7 @@ pub fn interval<F: Fn() -> MSG + 'static, MSG: 'static>(stream: &StreamHandle<MS
 /// After `duration` ms, emit `msg`.
 pub fn timeout<F: Fn() -> MSG + 'static, MSG: 'static>(stream: &StreamHandle<MSG>, duration: u32, constructor: F) {
     let stream = stream.clone();
-    gtk::timeout_add(duration, move || {
+    glib::timeout_add_local(duration, move || {
         let msg = constructor();
         stream.emit(msg);
         Continue(false)


### PR DESCRIPTION
While trying to reproduce the error you mentioned in #247, I trigger another error about the soon deprecated `gtk::timout_add`. This commit fixes that error. On my systems (arch and debian, this commit is backward compatible, hope the CI shows that).
I don't found the file you mentioned in #247 maybe you mixed up this repo with https://github.com/antoyo/statusbar.git ^^
IMO this issue can be closed.