### PR TITLE
refs #25: ability to set the widget style class through the view DSL

### DIFF
--- a/relm-derive/src/gen/gen.rs
+++ b/relm-derive/src/gen/gen.rs
@@ -388,6 +388,9 @@ impl<'a> Generator<'a> {
         let ident = quote! { #widget_name };
         let (properties, visible_properties) = self.gtk_set_prop_calls(widget, ident);
         let child_properties = gen_set_child_prop_calls(widget, parent, parent_widget_type, IsGtk);
+        let set_style_classes: Vec<_> = widget.style_classes.iter().map(|style_class|
+            quote_spanned! { widget_name.span() => gtk::StyleContextExt::add_class(&#widget_name.get_style_context(), &#style_class); }
+        ).collect();
 
         let show =
             if show {
@@ -404,6 +407,7 @@ impl<'a> Generator<'a> {
             #(#properties)*
             #(#children)*
             #add_child_or_show_all
+            #(#set_style_classes)*
             #show
             #(#visible_properties)*
             #(#child_properties)*

--- a/relm-derive/src/gen/parser.rs
+++ b/relm-derive/src/gen/parser.rs
@@ -419,7 +419,6 @@ impl Parse for Attributes {
                 match attribute.name_values.get("style_class") {
                     Some(Some(style_class)) => {
                         style_classes.insert(style_class.value());
-                        ()
                     },
                     Some(None) => panic!("Invalid style_class specification"),
                     None => name_values.extend(attribute.name_values)

--- a/relm-derive/src/gen/parser.rs
+++ b/relm-derive/src/gen/parser.rs
@@ -19,6 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+use std::collections::HashSet;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
@@ -130,6 +131,7 @@ pub struct Widget {
     pub save: bool,
     pub typ: Path,
     pub widget: EitherWidget,
+    pub style_classes: Vec<String>,
 }
 
 impl Widget {
@@ -152,6 +154,7 @@ impl Widget {
             save: false,
             typ,
             widget: Gtk(widget),
+            style_classes: vec![],
         }
     }
 
@@ -178,6 +181,7 @@ impl Widget {
             save: false,
             typ,
             widget: Relm(widget),
+            style_classes: vec![],
         }
     }
 }
@@ -400,17 +404,26 @@ impl Parse for Attribute {
 
 struct Attributes {
     name_values: HashMap<String, Option<LitStr>>,
+    style_classes: HashSet<String>,
 }
 
 impl Parse for Attributes {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut name_values = HashMap::new();
+        let mut style_classes = HashSet::new();
         loop {
             let lookahead = input.lookahead1();
 
             if lookahead.peek(Token![#]) {
                 let attribute: Attribute = input.parse()?;
-                name_values.extend(attribute.name_values);
+                match attribute.name_values.get("style_class") {
+                    Some(Some(style_class)) => {
+                        style_classes.insert(style_class.value());
+                        ()
+                    },
+                    Some(None) => panic!("Invalid style_class specification"),
+                    None => name_values.extend(attribute.name_values)
+                };
             }
             else {
                 break;
@@ -418,7 +431,8 @@ impl Parse for Attributes {
         }
 
         Ok(Attributes {
-            name_values
+            name_values,
+            style_classes
         })
     }
 }
@@ -488,18 +502,18 @@ struct ChildWidgetParser {
  */
 impl ChildWidgetParser {
     fn parse(root: SaveWidget, input: ParseStream) -> Result<Self> {
-        let attributes = Attributes::parse(&input)?.name_values;
+        let attributes = Attributes::parse(&input)?;
         let typ: WidgetPathParser = input.parse()?;
         let typ = typ.widget_path;
-        let save = attributes.contains_key("name") || root == Save;
+        let save = attributes.name_values.contains_key("name") || root == Save;
         match typ {
             RelmPath(_) => {
                 let relm_widget = RelmWidgetParser::parse(typ.get_relm_path().clone(), input)?.relm_widget;
-                Ok(adjust_widget_with_attributes(relm_widget, &attributes, save))
+                Ok(adjust_widget_with_attributes(relm_widget, &attributes.name_values, &attributes.style_classes, save))
             },
             GtkPath(_) => {
                 let gtk_widget = GtkWidgetParser::parse(typ.get_gtk_path().clone(), input)?.gtk_widget;
-                Ok(adjust_widget_with_attributes(gtk_widget, &attributes, save))
+                Ok(adjust_widget_with_attributes(gtk_widget, &attributes.name_values, &attributes.style_classes, save))
             },
         }
     }
@@ -1121,7 +1135,7 @@ fn path_to_string(path: &Path) -> String {
     string
 }
 
-fn adjust_widget_with_attributes(mut widget: ChildItem, attributes: &HashMap<String, Option<LitStr>>, save: bool)
+fn adjust_widget_with_attributes(mut widget: ChildItem, attributes: &HashMap<String, Option<LitStr>>, style_classes: &HashSet<String>, save: bool)
     -> ChildWidgetParser
 {
     let parent_id;
@@ -1133,6 +1147,10 @@ fn adjust_widget_with_attributes(mut widget: ChildItem, attributes: &HashMap<Str
             let name = attributes.get("name").and_then(|name| name.clone());
             if let Some(name) = name {
                 widget.name = Ident::new(&name.value(), name.span());
+            }
+            // style_class attribute
+            for style_class in style_classes {
+                widget.style_classes.push((*style_class).clone());
             }
             widget.is_container = !widget.children.is_empty();
             widget.container_type = container_type;

--- a/relm-examples/examples/buttons-attribute.rs
+++ b/relm-examples/examples/buttons-attribute.rs
@@ -84,6 +84,8 @@ impl Widget for Win {
                     text: &self.model.counter.to_string(),
                 },
                 #[name="dec_button"]
+                #[style_class="destructive-action"]
+                #[style_class="linked"]
                 gtk::Button {
                     clicked => Decrement,
                     label: "-",


### PR DESCRIPTION
I've wanted this feature in relm for a while, in my relm apps i have a bunch of `get_style_context().add_class()` calls in my `init_view` implementations.

The new `style_class` attribute must enable to specify multiple style classes for a widget.. currently I made it that you must repeat the attribute multiple times in the DSL. We could also change it so that the user can type `#[style_class=("destructive-action", "linked")]`. Let me know if you'd prefer that.

I also had to handle style classes specially in the `Attributes` struct, because with a Map of attributes, we couldn't list multiple times the style_class attribute. Again other approaches are possible, if you'd rather I do it another way, let me know!