### PR TITLE
Fixes clippy warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+      - name: "clippy"
+        run: cargo clippy -- --deny warnings
+
       # nightly
       - name: "relm: build nightly"
         run: cargo build

--- a/relm-derive/src/lib.rs
+++ b/relm-derive/src/lib.rs
@@ -145,5 +145,5 @@ fn remove_generic_bounds(generics: &Generics) -> Generics {
             _ => (),
         }
     }
-    generics.clone()
+    generics
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -156,7 +156,7 @@ impl<W: Clone + ContainerExt + IsA<gtk::Widget> + IsA<Object>> ContainerWidget f
         let (component, widget, child_relm) = create_widget::<CHILDWIDGET>(model_param);
         let container = widget.container().clone();
         let containers = widget.other_containers();
-        let root = widget.root().clone();
+        let root = widget.root();
         self.add(&root);
         widget.on_add(self.clone());
         init_component::<CHILDWIDGET>(component.owned_stream(), widget, &child_relm);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -64,7 +64,7 @@ impl<MSG> Clone for StreamHandle<MSG> {
 impl<MSG> StreamHandle<MSG> {
     fn new(stream: Weak<RefCell<_EventStream<MSG>>>) -> Self {
         Self {
-            stream: stream,
+            stream,
         }
     }
 
@@ -233,8 +233,10 @@ impl<MSG> SourceFuncs for SourceData<MSG> {
 
 }
 
+type Callback<MSG> = Rc<RefCell<Option<Box<dyn FnMut(MSG)>>>>;
+
 struct SourceData<MSG> {
-    callback: Rc<RefCell<Option<Box<dyn FnMut(MSG)>>>>,
+    callback: Callback<MSG>,
     stream: Rc<RefCell<_EventStream<MSG>>>,
 }
 
@@ -266,9 +268,8 @@ impl<MSG> Drop for EventStream<MSG> {
     }
 }
 
-
 impl<MSG> EventStream<MSG> {
-    fn get_callback(&self) -> Rc<RefCell<Option<Box<dyn FnMut(MSG)>>>> {
+    fn get_callback(&self) -> Callback<MSG> {
         source_get::<SourceData<MSG>>(&self.source).callback.clone()
     }
 

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -26,7 +26,6 @@ use std::ptr;
 use glib::Source;
 use glib::translate::{ToGlibPtr, from_glib_full};
 use glib_sys::{GSource, GSourceFunc, GSourceFuncs, g_source_new};
-use libc;
 
 pub trait SourceFuncs {
     fn check(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 //!
 //! More info can be found in the [readme](https://github.com/antoyo/relm#relm).
 
+#![allow(clippy::new_without_default)]
+
 #![warn(
     missing_docs,
     trivial_casts,
@@ -202,9 +204,11 @@ fn create_widget<WIDGET>(model_param: WIDGET::ModelParam)
     let mut widget = WIDGET::view(&relm, model);
     widget.init_view();
 
-    let root = widget.root().clone();
+    let root = widget.root();
     (Component::new(stream, root), widget, relm)
 }
+
+type InitTestComponents<WIDGET> = (Component<WIDGET>, <WIDGET as WidgetTest>::Streams, <WIDGET as WidgetTest>::Widgets);
 
 /// Initialize a widget for a test.
 ///
@@ -264,17 +268,17 @@ fn create_widget<WIDGET>(model_param: WIDGET::ModelParam)
 /// # }
 /// ```
 pub fn init_test<WIDGET>(model_param: WIDGET::ModelParam) ->
-    Result<(Component<WIDGET>, WIDGET::Streams, WIDGET::Widgets), ()>
+    Result<InitTestComponents<WIDGET>, glib::BoolError>
     where WIDGET: Widget + WidgetTest + 'static,
           WIDGET::Msg: DisplayVariant + 'static,
 {
-    gtk::init().map_err(|_| ())?;
+    gtk::init()?;
     let component = create_widget_test::<WIDGET>(model_param);
     Ok(component)
 }
 
 /// Initialize a widget.
-pub fn init<WIDGET>(model_param: WIDGET::ModelParam) -> Result<Component<WIDGET>, ()>
+pub fn init<WIDGET>(model_param: WIDGET::ModelParam) -> Result<Component<WIDGET>, glib::BoolError>
     where WIDGET: Widget + 'static,
           WIDGET::Msg: DisplayVariant + 'static
 {
@@ -332,10 +336,10 @@ pub fn init<WIDGET>(model_param: WIDGET::ModelParam) -> Result<Component<WIDGET>
 /// Win::run(()).expect("Win::run failed");
 /// # }
 /// ```
-pub fn run<WIDGET>(model_param: WIDGET::ModelParam) -> Result<(), ()>
+pub fn run<WIDGET>(model_param: WIDGET::ModelParam) -> Result<(), glib::BoolError>
     where WIDGET: Widget + 'static,
 {
-    gtk::init().map_err(|_| ())?;
+    gtk::init()?;
     let _component = init::<WIDGET>(model_param)?;
     gtk::main();
     Ok(())

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -20,7 +20,6 @@
  */
 
 use glib::{IsA, Object};
-use gtk;
 
 use super::{Relm, run};
 use crate::state::Update;
@@ -61,7 +60,7 @@ pub trait Widget
     fn root(&self) -> Self::Root;
 
     /// Create the window from this widget and start the main loop.
-    fn run(model_param: Self::ModelParam) -> Result<(), ()>
+    fn run(model_param: Self::ModelParam) -> Result<(), glib::BoolError>
         where Self: 'static,
     {
         run::<Self>(model_param)


### PR DESCRIPTION
Fixes #239 & #254

This PR is incomplete, there is still 4 warnings:
<details>

```
    Checking relm-derive v0.21.0 (/home/sanpi/sources/relm/relm-derive)                                                                                          [5/74]
warning: large size difference between variants
  --> src/gen/parser.rs:88:5
   |
88 |     Return(Expr, Expr),
   |     ^^^^^^^^^^^^^^^^^^ this variant is 560 bytes
   |
   = note: `#[warn(clippy::large_enum_variant)]` on by default
note: and the second-largest variant is 280 bytes:
  --> src/gen/parser.rs:87:5
   |
87 |     CallReturn(Expr),
   |     ^^^^^^^^^^^^^^^^
help: consider boxing the large fields to reduce the total size of the enum
  --> src/gen/parser.rs:88:5
   |
88 |     Return(Expr, Expr),
   |     ^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant

warning: this function has too many arguments (8/7)
   --> src/gen/parser.rs:137:5
    |
137 | /     fn new_gtk(widget: GtkWidget, typ: Path, init_parameters: Vec<Expr>, children: Vec<Widget>,
138 | |         properties: HashMap<Ident, Expr>, child_properties: ChildProperties, child_events: ChildEvents,
139 | |         nested_views: HashMap<Ident, Widget>) -> Self
    | |_____________________________________________________^
    |
    = note: `#[warn(clippy::too_many_arguments)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

warning: this function has too many arguments (8/7)
   --> src/gen/parser.rs:160:5
    |
160 | /     fn new_relm(widget: RelmWidget, typ: Path, init_parameters: Vec<Expr>, children: Vec<Widget>,
161 | |         properties: HashMap<Ident, Expr>, child_properties: ChildProperties, child_events: ChildEvents,
162 | |         nested_views: HashMap<Ident, Widget>) -> Self
    | |_____________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

warning: very complex type used. Consider factoring parts into `type` definitions
  --> src/gen/generator.rs:65:70
   |
65 | ...driver: &mut Driver) -> (TokenStream, HashMap<Ident, Path>, HashMap<Ident, Path>, HashSet<Ident>, TokenStream) {
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(clippy::type_complexity)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity

warning: 4 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.50s
```
</details>

I don’t know how fix that.