### PR TITLE
improve error message on empty view macro

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,10 @@ jobs:
             openbox &
             cargo test --manifest-path relm-examples/Cargo.toml -- --nocapture
 
+      - name: "relm-derive: tests"
+        run: |
+            cargo test --manifest-path relm-derive/Cargo.toml -- --nocapture
+
       - name: "relm: test examples"
         run: |
             Xvfb :99 &

--- a/relm-derive/Cargo.toml
+++ b/relm-derive/Cargo.toml
@@ -20,3 +20,8 @@ quote = "1.0"
 [dependencies.syn]
 features = ["extra-traits", "fold", "full", "visit"]
 version = "^1.0"
+
+[dev-dependencies]
+gtk = "^0.9.0"
+relm = { path = ".." }
+trybuild = "1.0.42"

--- a/relm-derive/tests/ui.rs
+++ b/relm-derive/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/relm-derive/tests/ui/empty_view_macro.rs
+++ b/relm-derive/tests/ui/empty_view_macro.rs
@@ -1,0 +1,15 @@
+#![allow(unused_imports)]
+
+use relm::Widget;
+use relm_derive::widget;
+
+#[widget]
+impl Widget for Foo {
+    fn model() {}
+
+    fn update(&mut self, _: ()) {}
+
+    view! {}
+}
+
+fn main() {}

--- a/relm-derive/tests/ui/empty_view_macro.stderr
+++ b/relm-derive/tests/ui/empty_view_macro.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of input, expected one of: string literal, identifier, `#`
+  --> $DIR/empty_view_macro.rs:12:11
+   |
+12 |     view! {}
+   |           ^^


### PR DESCRIPTION
Fixes #268.

This commit improves the error message emitted when an empty `view!` macro is provided. It also adds UI testing infrastructure to relm_derive, to make it easier to test future improvements to the macro. A new step for `relm_derive` tests is added to CI.

The existing unit tests in relm_derive do not compile, so they are removed.