### PR TITLE
Replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,10 +26,10 @@ jobs:
       - run: apt-get update -y
       - run: apt-get install -y libgtk-3-dev libglib2.0-dev libgraphene-1.0-dev git xvfb curl libcairo-gobject2 libcairo2-dev libxdo-dev libwebkit2gtk-4.0-dev openbox
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+          components: clippy
       - name: "clippy"
         run: cargo clippy -- --deny warnings
 


### PR DESCRIPTION
The actions-rs/toolchain repo seems to be [unmaintained](https://github.com/actions-rs/toolchain/issues/216) and a few issues have accumulated(https://github.com/actions-rs/toolchain/issues/221, https://github.com/actions-rs/toolchain/issues/219). It seems like dtolnay/rust-toolchain would be a better alternative and a number of repos have already switched to it.