### PR TITLE
Generate `glib::object::Object::new` instead of unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@
 //!
 //! More info can be found in the [readme](https://github.com/antoyo/relm#relm).
 
-#![allow(clippy::new_without_default, clippy::uninlined_format_args, unknown_lints)]
+#![allow(unknown_lints)]
+#![allow(clippy::new_without_default, clippy::uninlined_format_args)]
 
 #![warn(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! More info can be found in the [readme](https://github.com/antoyo/relm#relm).
 
-#![allow(clippy::new_without_default)]
+#![allow(clippy::new_without_default, clippy::uninlined_format_args)]
 
 #![warn(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! More info can be found in the [readme](https://github.com/antoyo/relm#relm).
 
-#![allow(clippy::new_without_default, clippy::uninlined_format_args)]
+#![allow(clippy::new_without_default, clippy::uninlined_format_args, unknown_lints)]
 
 #![warn(
     missing_docs,


### PR DESCRIPTION
This removes all unsafe code that was previously being generated by the proc macro. Also simplifies the code a bit.