### PR TITLE
added example using Cambalache ui file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ name: CI
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ubuntu:20.04
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,6 @@ name: CI
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container:
-      image: ubuntu:20.04
     strategy:
       matrix:
         rust:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,8 @@ name: CI
 jobs:
   build:
     runs-on: ubuntu-22.04
+    container:
+      image: ubuntu-22.04
     strategy:
       matrix:
         rust:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu-22.04
+      image: ubuntu:22.04
     strategy:
       matrix:
         rust:

--- a/relm-examples/Cargo.toml
+++ b/relm-examples/Cargo.toml
@@ -30,6 +30,6 @@ version = "^0.24.0"
 path = "../relm-test"
 version = "^0.24.0"
 
-[dependencies.adw]
+[dev-dependencies.adw]
 package = "libadwaita"
 version = "0.4.3"

--- a/relm-examples/Cargo.toml
+++ b/relm-examples/Cargo.toml
@@ -29,3 +29,7 @@ version = "^0.24.0"
 [dev-dependencies.relm-test]
 path = "../relm-test"
 version = "^0.24.0"
+
+[dependencies.adw]
+package = "libadwaita"
+version = "0.4.3"

--- a/relm-examples/examples/cambalache.rs
+++ b/relm-examples/examples/cambalache.rs
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020 Boucher, Antoni <bouanto@zoho.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This example uses the file "window.ui" exported from Cambalache v0.12.1.
+ * The file can be imported back into the same version of Cambalache and hopefuly
+ * later versions too.
+ */
+
+use adw::prelude::*;
+use adw::{ActionRow, Application, ApplicationWindow, HeaderBar};
+use gtk::{
+    prelude::BuilderExtManual,
+    Builder,
+    Button,
+    Inhibit,
+    Label,
+    Window,
+    prelude::ButtonExt,
+    prelude::LabelExt,
+    prelude::WidgetExt,
+};
+use relm_derive::Msg;
+use relm::{connect, Relm, Update, Widget, WidgetTest};
+
+struct Model {
+    counter: i32,
+}
+
+#[derive(Msg)]
+enum Msg {
+    Decrement,
+    Increment,
+    Quit,
+}
+
+// Create the structure that holds the widgets used in the view.
+#[derive(Clone)]
+struct Widgets {
+    counter_label: Label,
+    minus_button: Button,
+    plus_button: Button,
+    window: Window,
+}
+
+struct Win {
+    model: Model,
+    widgets: Widgets,
+}
+
+impl Update for Win {
+    // Specify the model used for this widget.
+    type Model = Model;
+    // Specify the model parameter used to init the model.
+    type ModelParam = ();
+    // Specify the type of the messages sent to the update function.
+    type Msg = Msg;
+
+    fn model(_: &Relm<Self>, _: ()) -> Model {
+        Model {
+            counter: 0,
+        }
+    }
+
+    fn update(&mut self, event: Msg) {
+        let label = &self.widgets.counter_label;
+
+        match event {
+            Msg::Decrement => {
+                self.model.counter -= 1;
+                // Manually update the view.
+                label.set_text(&self.model.counter.to_string());
+            },
+            Msg::Increment => {
+                self.model.counter += 1;
+                label.set_text(&self.model.counter.to_string());
+            },
+            Msg::Quit => gtk::main_quit(),
+        }
+    }
+}
+
+impl Widget for Win {
+    // Specify the type of the root widget.
+    type Root = Window;
+
+    // Return the root widget.
+    fn root(&self) -> Self::Root {
+        self.widgets.window.clone()
+    }
+
+    fn view(relm: &Relm<Self>, model: Self::Model) -> Self {
+        let glade_src = include_str!("window.ui");
+        let builder = Builder::from_string(glade_src);
+
+        let window: Window = builder.object("window").unwrap();
+        window.show_all();
+
+        let plus_button: Button = builder.object("plus_button").unwrap();
+        let minus_button: Button = builder.object("minus_button").unwrap();
+        let counter_label: Label = builder.object("counter_label").unwrap();
+
+        connect!(relm, plus_button, connect_clicked(_), Msg::Increment);
+        connect!(relm, minus_button, connect_clicked(_), Msg::Decrement);
+        connect!(relm, window, connect_delete_event(_, _), return (Some(Msg::Quit), Inhibit(false)));
+
+        Win {
+            model,
+            widgets: Widgets {
+                counter_label,
+                minus_button,
+                plus_button,
+                window: window,
+            },
+        }
+    }
+}
+
+impl WidgetTest for Win {
+    type Streams = ();
+
+    fn get_streams(&self) -> Self::Streams {
+    }
+
+    type Widgets = Widgets;
+
+    fn get_widgets(&self) -> Self::Widgets {
+        self.widgets.clone()
+    }
+}
+
+fn main() {
+    Win::run(()).expect("Win::run failed");
+}
+
+#[cfg(test)]
+mod tests {
+    use gtk::prelude::LabelExt;
+
+    use gtk_test::assert_text;
+    use relm_test::click;
+
+    use crate::Win;
+
+    #[test]
+    #[ignore]
+    fn label_change() {
+        let (_component, _, widgets) = relm::init_test::<Win>(()).expect("init_test failed");
+        let plus_button = &widgets.plus_button;
+        let minus_button = &widgets.minus_button;
+        let label = &widgets.counter_label;
+
+        assert_text!(label, 0);
+        click(plus_button);
+        assert_text!(label, 1);
+        click(plus_button);
+        assert_text!(label, 2);
+        click(plus_button);
+        assert_text!(label, 3);
+        click(plus_button);
+        assert_text!(label, 4);
+
+        click(minus_button);
+        assert_text!(label, 3);
+        click(minus_button);
+        assert_text!(label, 2);
+        click(minus_button);
+        assert_text!(label, 1);
+        click(minus_button);
+        assert_text!(label, 0);
+        click(minus_button);
+        assert_text!(label, -1);
+    }
+}

--- a/relm-examples/examples/window.ui
+++ b/relm-examples/examples/window.ui
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Created with Cambalache 0.12.1 -->
+<interface>
+  <!-- interface-name counter.ui -->
+  <requires lib="gtk" version="4.10"/>
+  <requires lib="libadwaita" version="1.3"/>
+  <object class="GtkApplicationWindow" id="window">
+    <property name="default-height">100</property>
+    <property name="default-width">400</property>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkButton" id="plus_button">
+            <property name="label">+</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="counter_label">
+            <property name="label">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="minus_button">
+            <property name="label">-</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
I would have liked to use an `AdwApplicationWindow` instead of a `GtkApplicationWindow` for the root widget, but I couldn't get it to work.