### PR TITLE
Re-export gtk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@
 //!
 //! ```toml
 //! [dependencies]
-//! gtk = "^0.6.0"
 //! relm = "^0.16.0"
 //! relm-derive = "^0.16.0"
 //! ```
@@ -121,6 +120,7 @@ pub use glib::translate::{FromGlibPtrNone, IntoGlib, ToGlibPtr};
 #[doc(hidden)]
 pub use gobject_sys::{GParameter, g_object_newv};
 use glib::Continue;
+pub use gtk;
 
 pub use crate::core::{Channel, EventStream, Sender, StreamHandle};
 pub use crate::state::{


### PR DESCRIPTION
Relm requires a relatively fixed version of gtk due to semver.

For example, at the time of submitting this PR, running
```
cargo add relm
cargo add gtk
```
will result in resolver errors because of `gtk 0.18` not being compatible with relm.