### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.65.0"
+          - "1.70.0"
     env:
         DISPLAY: ":99.0"
         # Workaround to avoid getting stuck by apt about choosing a timezone.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,6 @@ name: CI
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:20.04
     strategy:
       matrix:
         rust:
@@ -20,12 +18,9 @@ jobs:
           - "1.70.0"
     env:
         DISPLAY: ":99.0"
-        # Workaround to avoid getting stuck by apt about choosing a timezone.
-        DEBIAN_FRONTEND: noninteractive
-        TZ: America/New_York
     steps:
-      - run: apt-get update -y
-      - run: apt-get install -y libgtk-3-dev libglib2.0-dev libgraphene-1.0-dev git xvfb curl libcairo-gobject2 libcairo2-dev libxdo-dev libwebkit2gtk-4.0-dev openbox
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y libgtk-3-dev libglib2.0-dev libgraphene-1.0-dev git xvfb curl libcairo-gobject2 libcairo2-dev libxdo-dev libwebkit2gtk-4.0-dev openbox
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -34,14 +29,8 @@ jobs:
       - name: "clippy"
         run: cargo clippy -- --deny warnings
 
-      # nightly
-      - name: "relm: build nightly"
-        run: cargo build
-        if: matrix.rust == 'nightly'
-      # not nightly
       - name: "relm: build"
         run: cargo build
-        if: matrix.rust != 'nightly'
 
       - name: "relm: tests"
         run: |

--- a/relm-derive/src/gen/parser.rs
+++ b/relm-derive/src/gen/parser.rs
@@ -376,7 +376,7 @@ impl Parse for NameValue {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(NameValue {
             name: input.parse()?,
-            value: AttributeValue::parse(&input).ok(),
+            value: AttributeValue::parse(input).ok(),
         })
     }
 }
@@ -500,7 +500,7 @@ struct ChildWidgetParser {
  */
 impl ChildWidgetParser {
     fn parse(root: SaveWidget, input: ParseStream) -> Result<Self> {
-        let attributes = Attributes::parse(&input)?;
+        let attributes = Attributes::parse(input)?;
         let typ: WidgetPathParser = input.parse()?;
         let typ = typ.widget_path;
         let save = attributes.name_values.contains_key("name") || root == Save;
@@ -633,7 +633,7 @@ impl RelmWidgetParser {
                         Property(ident, value) => { let _ = properties.insert(ident, value.value); },
                         RelmMsg(ident, value) => { let _ = relm_widget.messages.insert(ident, value.value); },
                         RelmMsgEvent(ident, event) => {
-                            let events = relm_widget.events.entry(ident).or_insert_with(Vec::new);
+                            let events = relm_widget.events.entry(ident).or_default();
                             events.push(event);
                         },
                     }
@@ -1177,7 +1177,7 @@ pub fn respan_with(tokens: proc_macro::TokenStream, span: proc_macro::Span) -> p
             }
         }
     }
-    FromIterator::from_iter(result.into_iter())
+    FromIterator::from_iter(result)
 }
 
 pub fn dummy_ident(ident: &str) -> Ident {

--- a/relm-derive/src/gen/transformer.rs
+++ b/relm-derive/src/gen/transformer.rs
@@ -40,7 +40,7 @@ use syn::Member::Named;
 use super::parser::dummy_ident;
 
 thread_local! {
-    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    static COUNTER: AtomicUsize = const { AtomicUsize::new(0) };
 }
 
 pub struct Transformer {

--- a/relm-examples/examples/buttons.rs
+++ b/relm-examples/examples/buttons.rs
@@ -130,7 +130,7 @@ impl Widget for Win {
                 counter_label,
                 minus_button,
                 plus_button,
-                window: window,
+                window,
             },
         }
     }

--- a/relm-examples/examples/clock.rs
+++ b/relm-examples/examples/clock.rs
@@ -51,8 +51,8 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn subscriptions(&mut self, relm: &Relm<Self>) {
@@ -89,8 +89,8 @@ impl Widget for Win {
         connect!(relm, window, connect_delete_event(_, _), return (Some(Quit), Inhibit(false)));
 
         let mut win = Win {
-            label: label,
-            window: window,
+            label,
+            window,
         };
 
         win.update(Tick);

--- a/relm-examples/examples/core.rs
+++ b/relm-examples/examples/core.rs
@@ -83,8 +83,8 @@ fn main() {
     // As mentioned above, this struct holds the labels that we're going
     // to be updating.
     let widgets = Widgets {
-        clock_label: clock_label,
-        counter_label: counter_label,
+        clock_label,
+        counter_label,
     };
 
     // Create a new window and add our layout container to it.

--- a/relm-examples/examples/glade.rs
+++ b/relm-examples/examples/glade.rs
@@ -120,7 +120,7 @@ impl Widget for Win {
                 counter_label,
                 minus_button,
                 plus_button,
-                window: window,
+                window,
             },
         }
     }

--- a/relm-examples/examples/headerbar.rs
+++ b/relm-examples/examples/headerbar.rs
@@ -15,7 +15,7 @@ pub enum HeaderMsg {
 
 #[widget]
 impl Widget for Header {
-    fn model() -> () {
+    fn model() {
 
     }
 

--- a/relm-examples/examples/multi-window.rs
+++ b/relm-examples/examples/multi-window.rs
@@ -30,7 +30,7 @@ use self::Msg::*;
 
 #[widget]
 impl Widget for SecondaryWin {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: Msg) {

--- a/relm-examples/examples/nested-view-attribute.rs
+++ b/relm-examples/examples/nested-view-attribute.rs
@@ -79,8 +79,8 @@ impl Widget for Counter {
 
 #[widget]
 impl Widget for HBox {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, _event: ()) {

--- a/relm-examples/examples/readme.rs
+++ b/relm-examples/examples/readme.rs
@@ -65,7 +65,7 @@ impl Widget for Win {
 
         Win {
             model,
-            window: window,
+            window,
         }
     }
 }

--- a/relm-examples/examples/tabs.rs
+++ b/relm-examples/examples/tabs.rs
@@ -38,8 +38,8 @@ pub enum Msg {
 
 #[widget]
 impl Widget for Win {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/checkboxes.rs
+++ b/relm-examples/tests/checkboxes.rs
@@ -145,7 +145,7 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, event: Msg) {
@@ -196,7 +196,7 @@ impl Widget for Win {
             widgets: Widgets {
                 minus_button: minus_button.widget().clone(),
                 plus_button: plus_button.widget().clone(),
-                window: window,
+                window,
             },
             components: Components {
                 minus_button,

--- a/relm-examples/tests/child-event.rs
+++ b/relm-examples/tests/child-event.rs
@@ -57,7 +57,7 @@ impl Widget for TreeView {
         self.widgets.tree_view.set_model(Some(&model));
     }
 
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _event: Msg) {

--- a/relm-examples/tests/child-prop-attribute.rs
+++ b/relm-examples/tests/child-prop-attribute.rs
@@ -40,7 +40,7 @@ pub enum ButtonMsg {
 
 #[widget]
 impl Widget for Button {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: ButtonMsg) {

--- a/relm-examples/tests/child-prop.rs
+++ b/relm-examples/tests/child-prop.rs
@@ -59,7 +59,7 @@ impl Update for Button {
     type ModelParam = ();
     type Msg = ButtonMsg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _msg: ButtonMsg) {
@@ -89,7 +89,7 @@ impl Widget for Button {
         let button = gtk::Button::with_label("+");
 
         Button {
-            button: button,
+            button,
         }
     }
 }
@@ -121,7 +121,7 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, event: Msg) {
@@ -155,7 +155,7 @@ impl Widget for Win {
                 dec_button,
                 inc_button: relm_button.widget().clone(),
                 label,
-                window: window,
+                window,
             },
             _components: Components {
                 _inc_button: relm_button,

--- a/relm-examples/tests/communication.rs
+++ b/relm-examples/tests/communication.rs
@@ -107,9 +107,9 @@ impl Widget for Text {
         connect!(relm, input, connect_changed(_), Change(input2.text()));
 
         Text {
-            label: label,
+            label,
             model,
-            vbox: vbox,
+            vbox,
         }
     }
 }
@@ -183,9 +183,9 @@ impl Widget for Counter {
         connect!(relm, minus_button, connect_clicked(_), Decrement);
 
         Counter {
-            counter_label: counter_label,
+            counter_label,
             model,
-            vbox: vbox,
+            vbox,
         }
     }
 }

--- a/relm-examples/tests/container-attribute.rs
+++ b/relm-examples/tests/container-attribute.rs
@@ -39,7 +39,7 @@ pub enum ButtonMsg {
 
 #[widget]
 impl Widget for GtkButton {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: ButtonMsg) {
@@ -61,7 +61,7 @@ mod module {
 
     #[widget]
     impl Widget for Button {
-        fn model() -> () {
+        fn model() {
         }
 
         fn update(&mut self, _msg: ButtonMsg) {
@@ -75,8 +75,8 @@ mod module {
 
 #[widget]
 impl Widget for VBox {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, _event: Msg) {

--- a/relm-examples/tests/container.rs
+++ b/relm-examples/tests/container.rs
@@ -53,7 +53,7 @@ impl Update for Button {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -70,7 +70,7 @@ impl Widget for Button {
     fn view(_relm: &Relm<Self>, _model: ()) -> Self {
         let button = gtk::Button::with_label("+");
         Button {
-            button: button,
+            button,
         }
     }
 }
@@ -88,7 +88,7 @@ impl Container for VBox {
         &self.vbox
     }
 
-    fn other_containers(&self) -> () {
+    fn other_containers(&self) {
     }
 }
 
@@ -97,8 +97,8 @@ impl Update for VBox {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn update(&mut self, _event: ()) {
@@ -117,8 +117,8 @@ impl Widget for VBox {
         let vbox = gtk::Box::new(Vertical, 0);
         event_box.add(&vbox);
         VBox {
-            event_box: event_box,
-            vbox: vbox,
+            event_box,
+            vbox,
         }
     }
 }
@@ -151,7 +151,7 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, event: Msg) {
@@ -186,7 +186,7 @@ impl Widget for Win {
                 _vbox: vbox,
             },
             widgets: Widgets {
-                window: window,
+                window,
                 inc_button,
                 dec_button,
                 label,

--- a/relm-examples/tests/generic-widget-attribute.rs
+++ b/relm-examples/tests/generic-widget-attribute.rs
@@ -107,8 +107,8 @@ pub enum Msg {
 
 #[widget]
 impl Widget for Win {
-    fn model(_: ()) -> () {
-        ()
+    fn model(_: ()) {
+        
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/generic-widget.rs
+++ b/relm-examples/tests/generic-widget.rs
@@ -136,9 +136,9 @@ impl<T: Clone + IncDec + Display + 'static> Widget for Counter<T> {
         connect!(relm, minus_button, connect_clicked(_), Decrement);
 
         Counter {
-            counter_label: counter_label,
+            counter_label,
             model,
-            vbox: vbox,
+            vbox,
         }
     }
 }
@@ -170,8 +170,8 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn update(&mut self, event: Msg) {
@@ -205,7 +205,7 @@ impl Widget for Win {
             widgets: Widgets {
                 counter1: counter1.widget().clone(),
                 counter2: counter2.widget().clone(),
-                window: window,
+                window,
             },
             _components: Components {
                 _counter1: counter1,

--- a/relm-examples/tests/model-param-attribute.rs
+++ b/relm-examples/tests/model-param-attribute.rs
@@ -73,7 +73,7 @@ impl Widget for Win {
     // The initial model.
     fn model(counter: i32) -> Model {
         Model {
-            counter: counter,
+            counter,
             initial_text: "+",
         }
     }

--- a/relm-examples/tests/model-param-widget-attribute.rs
+++ b/relm-examples/tests/model-param-widget-attribute.rs
@@ -40,7 +40,7 @@ pub struct ButtonModel {
 impl Widget for Button {
     fn model(text: String) -> ButtonModel {
         ButtonModel {
-            text: text,
+            text,
         }
     }
 
@@ -72,7 +72,7 @@ impl Widget for Win {
     // The initial model.
     fn model(counter: i32) -> Model {
         Model {
-            counter: counter,
+            counter,
         }
     }
 

--- a/relm-examples/tests/model-param.rs
+++ b/relm-examples/tests/model-param.rs
@@ -68,7 +68,7 @@ impl Update for Win {
 
     fn model(_: &Relm<Self>, counter: i32) -> Model {
         Model {
-            counter: counter,
+            counter,
         }
     }
 

--- a/relm-examples/tests/multi-container-attribute.rs
+++ b/relm-examples/tests/multi-container-attribute.rs
@@ -35,7 +35,7 @@ use self::Msg::*;
 
 #[widget]
 impl Widget for MyFrame {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -50,7 +50,7 @@ impl Widget for MyFrame {
 
 #[widget]
 impl Widget for CenterButton {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -66,7 +66,7 @@ impl Widget for CenterButton {
 
 #[widget]
 impl Widget for Button {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -83,8 +83,8 @@ impl Widget for Button {
 
 #[widget]
 impl Widget for SplitBox {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, _event: Msg) {

--- a/relm-examples/tests/multi-container.rs
+++ b/relm-examples/tests/multi-container.rs
@@ -54,7 +54,7 @@ impl Update for CenterButton {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -75,7 +75,7 @@ impl Widget for CenterButton {
     fn view(_relm: &Relm<Self>, _model: ()) -> Self {
         let button = gtk::Button::with_label("-");
         CenterButton {
-            button: button,
+            button,
         }
     }
 }
@@ -89,7 +89,7 @@ impl Update for Button {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -110,7 +110,7 @@ impl Widget for Button {
     fn view(_relm: &Relm<Self>, _model: ()) -> Self {
         let button = gtk::Button::with_label("+");
         Button {
-            button: button,
+            button,
         }
     }
 }
@@ -124,7 +124,7 @@ impl Update for MyFrame {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -210,8 +210,8 @@ impl Update for SplitBox {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn update(&mut self, _event: ()) {
@@ -272,7 +272,7 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/multi-generic-widget-attribute.rs
+++ b/relm-examples/tests/multi-generic-widget-attribute.rs
@@ -117,8 +117,8 @@ pub enum Msg {
 
 #[widget]
 impl Widget for Win {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/multi-generic-widget.rs
+++ b/relm-examples/tests/multi-generic-widget.rs
@@ -144,9 +144,9 @@ impl<S: Clone + Display + IncDec, T: Clone + Display + IncDec> Widget for Counte
         connect!(relm, minus_button, connect_clicked(_), Decrement);
 
         Counter {
-            counter_label: counter_label,
+            counter_label,
             model,
-            vbox: vbox,
+            vbox,
             _phantom1: PhantomData,
             _phantom2: PhantomData,
         }
@@ -180,8 +180,8 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn update(&mut self, event: Msg) {
@@ -215,7 +215,7 @@ impl Widget for Win {
             widgets: Widgets {
                 counter1: counter1.widget().clone(),
                 counter2: counter2.widget().clone(),
-                window: window,
+                window,
             },
             _components: Components {
                 _counter1: counter1,

--- a/relm-examples/tests/multiple-widgets-attribute.rs
+++ b/relm-examples/tests/multiple-widgets-attribute.rs
@@ -126,8 +126,8 @@ pub enum Msg {
 
 #[widget]
 impl Widget for Win {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/multiple-widgets.rs
+++ b/relm-examples/tests/multiple-widgets.rs
@@ -219,8 +219,8 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/references.rs
+++ b/relm-examples/tests/references.rs
@@ -24,7 +24,7 @@ use std::cell::Cell;
 use relm::{Update, Widget};
 
 thread_local! {
-    static DROPPED: Cell<bool> = Cell::new(false);
+    static DROPPED: Cell<bool> = const { Cell::new(false) };
 }
 
 pub struct Item {

--- a/relm-examples/tests/references2.rs
+++ b/relm-examples/tests/references2.rs
@@ -26,7 +26,7 @@ use relm::{ContainerWidget, Widget, connect};
 use relm_derive::Msg;
 
 thread_local! {
-    static DROP_COUNT: Cell<i32> = Cell::new(0);
+    static DROP_COUNT: Cell<i32> = const { Cell::new(0) };
 }
 
 macro_rules! assert_drop_count {
@@ -93,7 +93,7 @@ impl relm::Update for RelmWidget {
     type Msg = Msg;
 
     fn model(_relm: &relm::Relm<Self>, _param: ()) -> Self::Model {
-        ()
+        
     }
 
     fn update(&mut self, e: Msg) {

--- a/relm-examples/tests/relm-root-attribute.rs
+++ b/relm-examples/tests/relm-root-attribute.rs
@@ -34,7 +34,7 @@ use self::Msg::*;
 
 #[widget]
 impl Widget for Button {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -49,8 +49,8 @@ impl Widget for Button {
 
 #[widget]
 impl Widget for VBox {
-    fn model() -> () {
-        ()
+    fn model() {
+        
     }
 
     fn update(&mut self, _event: Msg) {
@@ -111,7 +111,7 @@ pub enum Msg {
 
 #[widget]
 impl Widget for Win {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/relm-root.rs
+++ b/relm-examples/tests/relm-root.rs
@@ -54,7 +54,7 @@ impl Update for Button {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _msg: ()) {
@@ -72,7 +72,7 @@ impl Widget for Button {
         let button = gtk::Button::with_label("+");
         button.set_widget_name("button");
         Button {
-            button: button,
+            button,
         }
     }
 }
@@ -90,7 +90,7 @@ impl Container for VBox {
         &self.vbox
     }
 
-    fn other_containers(&self) -> () {
+    fn other_containers(&self) {
     }
 }
 
@@ -99,8 +99,8 @@ impl Update for VBox {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
-        ()
+    fn model(_: &Relm<Self>, _: ()) {
+        
     }
 
     fn update(&mut self, _event: ()) {
@@ -120,8 +120,8 @@ impl Widget for VBox {
         event_box.add(&vbox);
 
         VBox {
-            event_box: event_box,
-            vbox: vbox,
+            event_box,
+            vbox,
         }
     }
 }
@@ -136,7 +136,7 @@ impl Update for MyVBox {
     type ModelParam = ();
     type Msg = ();
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, _event: ()) {
@@ -168,7 +168,7 @@ impl Widget for MyVBox {
         vbox.add(&minus_button);
 
         MyVBox {
-            vbox: vbox,
+            vbox,
             _widget: widget,
         }
     }
@@ -199,7 +199,7 @@ impl Update for Win {
     type ModelParam = ();
     type Msg = Msg;
 
-    fn model(_: &Relm<Self>, _: ()) -> () {
+    fn model(_: &Relm<Self>, _: ()) {
     }
 
     fn update(&mut self, event: Msg) {

--- a/relm-examples/tests/simple.rs
+++ b/relm-examples/tests/simple.rs
@@ -68,7 +68,7 @@ pub enum Msg {
 
 #[widget]
 impl Widget for Win {
-    fn model() -> () {
+    fn model() {
     }
 
     fn update(&mut self, event: Msg) {

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -9,7 +9,6 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 use cairo::{
-    self,
     Context,
     Format,
     ImageSurface,


### PR DESCRIPTION
Originally I planed to update the enigo dependeny to it's newest version. To ensure there are no regressions, I fixed the CI first. I then noticed that gtk-test has been deprecated. It depends on enigos old version, so I think there would be a version conflict and I stopped.

In order to get the CI working again, I had to fix some clippy lints and bump up the Rust version. I also made some optional changes to the CI to make it nicer to work with. The CI no longer uses a container and thus is a faster. Fails jobs no longer cancel other jobs.